### PR TITLE
Add VR Pause Menu system to XR_Module_Template

### DIFF
--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class PauseMenu : MonoBehaviour
+{
+    [Header("Pause Menu")]
+    public GameObject pausePanel;
+
+    [Header("Input")]
+    public InputActionReference pauseButton;
+
+    private bool isPaused = false;
+
+    private void OnEnable()
+    {
+        pauseButton.action.Enable();
+        pauseButton.action.performed += OnPausePressed;
+    }
+
+    private void OnDisable()
+    {
+        pauseButton.action.performed -= OnPausePressed;
+    }
+
+    private void OnPausePressed(InputAction.CallbackContext context)
+    {
+        TogglePause();
+    }
+
+    // TEMP: keyboard test
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.P))
+        {
+            TogglePause();
+        }
+        if (Input.GetKeyDown(KeyCode.R))
+        {
+            ResumeGame();
+        }
+    }
+
+    public void TogglePause()
+    {
+        isPaused = !isPaused;
+
+        if (isPaused)
+        {
+            // Position panel in front of camera
+            Camera cam = Camera.main;
+            pausePanel.transform.position = cam.transform.position + cam.transform.forward * 2f;
+            pausePanel.transform.rotation = Quaternion.LookRotation(cam.transform.forward);
+        }
+
+        pausePanel.SetActive(isPaused);
+    }
+
+    public void ResumeGame()
+    {
+        isPaused = false;
+        pausePanel.SetActive(false);
+    }
+
+    public void RestartScene()
+    {
+        UnityEngine.SceneManagement.SceneManager.LoadScene(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene().name);
+    }
+}

--- a/Assets/Scripts/PauseMenu.cs.meta
+++ b/Assets/Scripts/PauseMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 862d8f6e42acb3f418d1f08897bacc17


### PR DESCRIPTION
## Changes
- Added wrist-mounted Pause button parented to Left Controller
- Added PauseMenuCanvas with Resume, Restart, and Return to Main Menu buttons
- Added PauseMenu.cs script handling toggle logic and camera-relative positioning
- Pause panel appears in front of player's view when triggered
- Return to Main Menu uses existing SceneFader for smooth transition
- Deleted duplicate PauseMenu.cs from Assets/Code/Scripts (conflict with Assets/Scripts)

## Notes
- Wrist button position is designed for physical VR controllers
- In XR Device Simulator, button floats near left controller as expected
- Keyboard shortcuts P (pause) and R (resume) included for desktop testing